### PR TITLE
update vscodium executable path

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -37,7 +37,7 @@ var (
 	// Candidate paths to `code` command-line program.
 	codePaths = []string{
 		"/usr/local/bin/code",
-		"/Applications/VSCodium.app/Contents/Resources/app/bin/code",
+		"/Applications/VSCodium.app/Contents/Resources/app/bin/codium",
 		"/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code",
 	}
 )


### PR DESCRIPTION
Hi -- first, thanks for the wonderful workflow!

The workflow doesn't work properly with VSCodium on my end. From a quick look, the path seems to be the culprit, since Codium doesn't seem to ship with a `code` executable (indeed, inside `Applications/VSCodium.app/Contents/Resources/app/bin/`,  simply duplicating `codium` as `code` fixed the workflow), hence the PR. Thanks!